### PR TITLE
[FIX] Pass milliseconds instead of microseconds when sending a DateTime to the native SDKs

### DIFF
--- a/lib/piano_analytics.dart
+++ b/lib/piano_analytics.dart
@@ -256,7 +256,7 @@ class PianoAnalyticsMessageCodec extends StandardMessageCodec {
   void writeValue(WriteBuffer buffer, dynamic value) {
     if (value is DateTime) {
       buffer.putUint8(dateType);
-      buffer.putInt64(value.microsecondsSinceEpoch);
+      buffer.putInt64(value.millisecondsSinceEpoch);
     } else {
       super.writeValue(buffer, value);
     }
@@ -265,7 +265,7 @@ class PianoAnalyticsMessageCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     if (type == dateType) {
-      return DateTime.fromMicrosecondsSinceEpoch(buffer.getInt64());
+      return DateTime.fromMillisecondsSinceEpoch(buffer.getInt64());
     }
     return super.readValueOfType(type, buffer);
   }


### PR DESCRIPTION
The Piano servers actually await a timestamp in milliseconds, the current SDK produces wrong display in Piano Dashboard such as below :

<img width="393" height="201" alt="image" src="https://github.com/user-attachments/assets/c6aca234-3f56-4aea-b793-da9b75ff24be" />

Fixes https://github.com/at-internet/piano-analytics-flutter/issues/11